### PR TITLE
Add Elementor admin dashboard plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
-# elguide.nu
+# elguide.nu WordPress Assets
+
+This repository contains custom WordPress integrations for elguide.nu. The `elementor-admin-dashboard` plugin provides an Elementor Pro-ready admin dashboard widget that surfaces WordPress metrics and quick links. See the plugin README for installation and usage instructions.

--- a/elementor-admin-dashboard/README.md
+++ b/elementor-admin-dashboard/README.md
@@ -1,0 +1,50 @@
+# Elementor Admin Dashboard
+
+This plugin adds a customizable admin-style dashboard widget that can be edited visually with **Elementor Pro**. Use it to build client-facing control centers, intranet dashboards, or reporting pages that surface real-time WordPress metrics together with your own quick links.
+
+## Features
+
+- Elementor widget that exposes WordPress statistics (posts, pages, comments, users).
+- Repeater control to add custom quick links for popular admin destinations or external tools.
+- Responsive card layout with style controls for colors, typography, spacing, borders, and shadows.
+- Optional custom post type for saving multiple dashboard layouts and sharing them with different users.
+- Ready-to-use styling that looks great out of the box but can be fully adjusted in Elementor Pro.
+
+## Requirements
+
+- WordPress 6.0+
+- PHP 7.4+
+- [Elementor](https://elementor.com/) 3.0 or higher (Elementor Pro recommended for Theme Builder templates).
+
+## Installation
+
+1. Copy the `elementor-admin-dashboard` folder into your WordPress installation under `wp-content/plugins/`.
+2. Log in to the WordPress admin dashboard and activate **Elementor Admin Dashboard** under **Plugins → Installed Plugins**.
+3. Ensure Elementor (and Elementor Pro if you use Theme Builder) is active.
+
+## Creating a Dashboard in Elementor
+
+1. Create a new page (or template) and open it with Elementor.
+2. Search for **Admin Dashboard** in the Elementor widget panel.
+3. Drag the widget onto the canvas. Real WordPress stats are loaded automatically.
+4. Configure the widget settings:
+   - Toggle which metrics to display.
+   - Choose between the "Cards" or "Minimal" layout.
+   - Adjust the column count for the metric cards.
+   - Add custom quick links with labels and URLs (internal or external).
+5. Use the **Style** tab to edit typography, colors, paddings, borders, and shadows so the dashboard matches your branding.
+6. Publish the page. You can optionally restrict access with your favorite membership or user-role plugin.
+
+## Saving Dashboards as Templates
+
+The plugin registers a custom post type **Admin Dashboards** under the WordPress admin menu. You can use this post type to save dashboard layouts, attach featured images, or collaborate with other editors. Pair it with Elementor Theme Builder templates or shortcodes for advanced workflows.
+
+## Developer Notes
+
+- Metrics can be filtered via the `elementor_admin_dashboard_metrics` filter.
+- CSS is enqueued in the Elementor editor and on the frontend when the widget renders.
+- The plugin is namespaced with the `Elementor_Admin_Dashboard_` prefix to avoid conflicts.
+
+## Support
+
+This plugin is provided as-is. For feature requests or issues please open a ticket in your preferred project management tool or contact the development team behind elguide.nu.

--- a/elementor-admin-dashboard/admin-dashboard-elementor.php
+++ b/elementor-admin-dashboard/admin-dashboard-elementor.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Plugin Name: Elementor Admin Dashboard
+ * Description: Provides an Elementor-ready admin dashboard template with WordPress statistics, shortcuts, and integrations.
+ * Version: 1.0.0
+ * Author: elguide.nu
+ * Text Domain: elementor-admin-dashboard
+ * Requires Plugins: elementor
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+if ( ! class_exists( 'Elementor_Admin_Dashboard_Plugin' ) ) {
+    require_once __DIR__ . '/includes/class-admin-dashboard-plugin.php';
+}
+
+Elementor_Admin_Dashboard_Plugin::instance();

--- a/elementor-admin-dashboard/assets/css/admin-dashboard.css
+++ b/elementor-admin-dashboard/assets/css/admin-dashboard.css
@@ -1,0 +1,99 @@
+.ade-dashboard-wrapper {
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+}
+
+.ade-dashboard-metrics {
+    display: grid;
+    gap: 16px;
+}
+
+.ade-dashboard-wrapper[data-columns="1"] .ade-dashboard-metrics {
+    grid-template-columns: repeat(1, minmax(0, 1fr));
+}
+
+.ade-dashboard-wrapper[data-columns="2"] .ade-dashboard-metrics {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.ade-dashboard-wrapper[data-columns="3"] .ade-dashboard-metrics {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.ade-dashboard-wrapper[data-columns="4"] .ade-dashboard-metrics {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.ade-dashboard-card {
+    background-color: #ffffff;
+    border-radius: 12px;
+    padding: 24px;
+    border: 1px solid rgba(15, 23, 42, 0.08);
+    box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.ade-dashboard-card:hover {
+    transform: translateY(-3px);
+    box-shadow: 0 20px 40px rgba(15, 23, 42, 0.12);
+}
+
+.ade-dashboard-card-title {
+    font-size: 0.95rem;
+    font-weight: 600;
+    color: #475569;
+    margin-bottom: 8px;
+}
+
+.ade-dashboard-card-value {
+    font-size: 2rem;
+    font-weight: 700;
+    color: #0f172a;
+}
+
+.ade-layout-minimal .ade-dashboard-card {
+    border-radius: 8px;
+    padding: 18px;
+    box-shadow: none;
+    border: 1px solid rgba(148, 163, 184, 0.35);
+}
+
+.ade-dashboard-shortcuts {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px 20px;
+}
+
+.ade-dashboard-shortcut a {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 10px 18px;
+    border-radius: 999px;
+    background: rgba(37, 99, 235, 0.12);
+    color: #1d4ed8;
+    font-weight: 600;
+    text-decoration: none;
+    transition: background 0.2s ease, color 0.2s ease;
+}
+
+.ade-dashboard-shortcut a:hover {
+    background: #1d4ed8;
+    color: #ffffff;
+}
+
+@media (max-width: 768px) {
+    .ade-dashboard-wrapper[data-columns="3"] .ade-dashboard-metrics,
+    .ade-dashboard-wrapper[data-columns="4"] .ade-dashboard-metrics {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+}
+
+@media (max-width: 480px) {
+    .ade-dashboard-wrapper[data-columns="2"] .ade-dashboard-metrics,
+    .ade-dashboard-wrapper[data-columns="3"] .ade-dashboard-metrics,
+    .ade-dashboard-wrapper[data-columns="4"] .ade-dashboard-metrics {
+        grid-template-columns: repeat(1, minmax(0, 1fr));
+    }
+}

--- a/elementor-admin-dashboard/includes/class-admin-dashboard-plugin.php
+++ b/elementor-admin-dashboard/includes/class-admin-dashboard-plugin.php
@@ -1,0 +1,169 @@
+<?php
+/**
+ * Core loader for the Elementor Admin Dashboard plugin.
+ *
+ * @package Elementor_Admin_Dashboard
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+if ( ! class_exists( 'Elementor_Admin_Dashboard_Plugin' ) ) {
+    /**
+     * Elementor Admin Dashboard bootstrapper.
+     */
+    class Elementor_Admin_Dashboard_Plugin {
+        const VERSION                   = '1.0.0';
+        const MINIMUM_ELEMENTOR_VERSION = '3.0.0';
+        const MINIMUM_PHP_VERSION       = '7.4';
+
+        /**
+         * Singleton instance.
+         *
+         * @var Elementor_Admin_Dashboard_Plugin
+         */
+        private static $instance;
+
+        /**
+         * Retrieve the singleton instance.
+         *
+         * @return Elementor_Admin_Dashboard_Plugin
+         */
+        public static function instance() {
+            if ( null === self::$instance ) {
+                self::$instance = new self();
+            }
+
+            return self::$instance;
+        }
+
+        /**
+         * Elementor_Admin_Dashboard_Plugin constructor.
+         */
+        private function __construct() {
+            add_action( 'init', array( $this, 'register_post_type' ) );
+            add_action( 'plugins_loaded', array( $this, 'on_plugins_loaded' ) );
+            add_action( 'elementor/frontend/after_register_styles', array( $this, 'register_styles' ) );
+            add_action( 'wp_enqueue_scripts', array( $this, 'register_styles' ) );
+            add_action( 'admin_enqueue_scripts', array( $this, 'register_styles' ) );
+            add_action( 'elementor/frontend/after_enqueue_styles', array( $this, 'enqueue_frontend_assets' ) );
+        }
+
+        /**
+         * Run checks after all plugins have loaded.
+         */
+        public function on_plugins_loaded() {
+            if ( ! did_action( 'elementor/loaded' ) ) {
+                add_action( 'admin_notices', array( $this, 'elementor_missing_notice' ) );
+                return;
+            }
+
+            if ( version_compare( PHP_VERSION, self::MINIMUM_PHP_VERSION, '<' ) ) {
+                add_action( 'admin_notices', array( $this, 'php_version_notice' ) );
+                return;
+            }
+
+            if ( ! class_exists( '\\Elementor\\Plugin' ) ) {
+                return;
+            }
+
+            require_once __DIR__ . '/class-elementor-admin-dashboard-widget.php';
+            add_action( 'elementor/widgets/register', array( $this, 'register_widget' ) );
+            add_action( 'elementor/editor/after_enqueue_scripts', array( $this, 'enqueue_editor_assets' ) );
+        }
+
+        /**
+         * Register scripts and styles needed for the widget.
+         */
+        public function register_styles() {
+            wp_register_style(
+                'elementor-admin-dashboard',
+                plugins_url( '../assets/css/admin-dashboard.css', __FILE__ ),
+                array(),
+                self::VERSION
+            );
+        }
+
+        /**
+         * Enqueue assets in the Elementor editor to preview styling.
+         */
+        public function enqueue_editor_assets() {
+            wp_enqueue_style( 'elementor-admin-dashboard' );
+        }
+
+        /**
+         * Register the custom Elementor widget.
+         *
+         * @param \Elementor\Widgets_Manager $widgets_manager Widgets manager instance.
+         */
+        public function register_widget( $widgets_manager ) {
+            $widgets_manager->register( new Elementor_Admin_Dashboard_Widget() );
+        }
+
+        /**
+         * Register a custom post type used to store admin dashboard layouts.
+         */
+        public function register_post_type() {
+            $labels = array(
+                'name'               => __( 'Admin Dashboards', 'elementor-admin-dashboard' ),
+                'singular_name'      => __( 'Admin Dashboard', 'elementor-admin-dashboard' ),
+                'add_new'            => __( 'Add New', 'elementor-admin-dashboard' ),
+                'add_new_item'       => __( 'Add New Admin Dashboard', 'elementor-admin-dashboard' ),
+                'edit_item'          => __( 'Edit Admin Dashboard', 'elementor-admin-dashboard' ),
+                'new_item'           => __( 'New Admin Dashboard', 'elementor-admin-dashboard' ),
+                'view_item'          => __( 'View Admin Dashboard', 'elementor-admin-dashboard' ),
+                'search_items'       => __( 'Search Admin Dashboards', 'elementor-admin-dashboard' ),
+                'not_found'          => __( 'No admin dashboards found.', 'elementor-admin-dashboard' ),
+                'not_found_in_trash' => __( 'No admin dashboards found in Trash.', 'elementor-admin-dashboard' ),
+            );
+
+            $args = array(
+                'labels'             => $labels,
+                'public'             => false,
+                'show_ui'            => true,
+                'show_in_menu'       => true,
+                'menu_icon'          => 'dashicons-analytics',
+                'supports'           => array( 'title', 'editor', 'thumbnail' ),
+                'show_in_rest'       => true,
+            );
+
+            register_post_type( 'elementor_admin_dashboard', $args );
+        }
+
+        /**
+         * Enqueue assets on the Elementor frontend when required.
+         */
+        public function enqueue_frontend_assets() {
+            wp_enqueue_style( 'elementor-admin-dashboard' );
+        }
+
+        /**
+         * Display admin notice when Elementor is missing.
+         */
+        public function elementor_missing_notice() {
+            if ( isset( $_GET['activate'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+                unset( $_GET['activate'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+            }
+
+            printf(
+                '<div class="notice notice-warning is-dismissible"><p>%s</p></div>',
+                esc_html__( 'Elementor Admin Dashboard requires Elementor to be installed and activated.', 'elementor-admin-dashboard' )
+            );
+        }
+
+        /**
+         * Display admin notice when PHP version is too low.
+         */
+        public function php_version_notice() {
+            if ( isset( $_GET['activate'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+                unset( $_GET['activate'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+            }
+
+            printf(
+                '<div class="notice notice-warning is-dismissible"><p>%s</p></div>',
+                esc_html__( 'Elementor Admin Dashboard requires PHP version 7.4 or higher.', 'elementor-admin-dashboard' )
+            );
+        }
+    }
+}

--- a/elementor-admin-dashboard/includes/class-elementor-admin-dashboard-widget.php
+++ b/elementor-admin-dashboard/includes/class-elementor-admin-dashboard-widget.php
@@ -1,0 +1,425 @@
+<?php
+/**
+ * Elementor widget for rendering the admin dashboard overview.
+ *
+ * @package Elementor_Admin_Dashboard
+ */
+
+use Elementor\Controls_Manager;
+use Elementor\Repeater;
+use Elementor\Widget_Base;
+use Elementor\Group_Control_Typography;
+use Elementor\Group_Control_Box_Shadow;
+use Elementor\Group_Control_Border;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+if ( ! class_exists( 'Elementor_Admin_Dashboard_Widget' ) ) {
+    /**
+     * Admin Dashboard Elementor widget.
+     */
+    class Elementor_Admin_Dashboard_Widget extends Widget_Base {
+        /**
+         * Get widget name.
+         *
+         * @return string
+         */
+        public function get_name() {
+            return 'elementor-admin-dashboard';
+        }
+
+        /**
+         * Get widget title.
+         *
+         * @return string
+         */
+        public function get_title() {
+            return __( 'Admin Dashboard', 'elementor-admin-dashboard' );
+        }
+
+        /**
+         * Get widget icon.
+         *
+         * @return string
+         */
+        public function get_icon() {
+            return 'eicon-dashboard';
+        }
+
+        /**
+         * Get widget categories.
+         *
+         * @return array
+         */
+        public function get_categories() {
+            return array( 'general' );
+        }
+
+        /**
+         * Get widget keywords.
+         *
+         * @return array
+         */
+        public function get_keywords() {
+            return array( 'dashboard', 'admin', 'analytics', 'panel', 'statistics' );
+        }
+
+        /**
+         * Register widget controls.
+         */
+        protected function register_controls() {
+            $this->start_controls_section(
+                'section_content',
+                array(
+                    'label' => __( 'Metrics', 'elementor-admin-dashboard' ),
+                )
+            );
+
+            $this->add_control(
+                'show_posts',
+                array(
+                    'label'        => __( 'Show Posts Count', 'elementor-admin-dashboard' ),
+                    'type'         => Controls_Manager::SWITCHER,
+                    'label_on'     => __( 'Yes', 'elementor-admin-dashboard' ),
+                    'label_off'    => __( 'No', 'elementor-admin-dashboard' ),
+                    'return_value' => 'yes',
+                    'default'      => 'yes',
+                )
+            );
+
+            $this->add_control(
+                'show_pages',
+                array(
+                    'label'        => __( 'Show Pages Count', 'elementor-admin-dashboard' ),
+                    'type'         => Controls_Manager::SWITCHER,
+                    'label_on'     => __( 'Yes', 'elementor-admin-dashboard' ),
+                    'label_off'    => __( 'No', 'elementor-admin-dashboard' ),
+                    'return_value' => 'yes',
+                    'default'      => 'yes',
+                )
+            );
+
+            $this->add_control(
+                'show_comments',
+                array(
+                    'label'        => __( 'Show Comments Count', 'elementor-admin-dashboard' ),
+                    'type'         => Controls_Manager::SWITCHER,
+                    'label_on'     => __( 'Yes', 'elementor-admin-dashboard' ),
+                    'label_off'    => __( 'No', 'elementor-admin-dashboard' ),
+                    'return_value' => 'yes',
+                    'default'      => 'yes',
+                )
+            );
+
+            $this->add_control(
+                'show_users',
+                array(
+                    'label'        => __( 'Show Users Count', 'elementor-admin-dashboard' ),
+                    'type'         => Controls_Manager::SWITCHER,
+                    'label_on'     => __( 'Yes', 'elementor-admin-dashboard' ),
+                    'label_off'    => __( 'No', 'elementor-admin-dashboard' ),
+                    'return_value' => 'yes',
+                    'default'      => 'yes',
+                )
+            );
+
+            $this->add_control(
+                'layout_style',
+                array(
+                    'label'   => __( 'Layout Style', 'elementor-admin-dashboard' ),
+                    'type'    => Controls_Manager::SELECT,
+                    'default' => 'cards',
+                    'options' => array(
+                        'cards'   => __( 'Cards', 'elementor-admin-dashboard' ),
+                        'minimal' => __( 'Minimal', 'elementor-admin-dashboard' ),
+                    ),
+                )
+            );
+
+            $this->add_control(
+                'columns',
+                array(
+                    'label'   => __( 'Columns', 'elementor-admin-dashboard' ),
+                    'type'    => Controls_Manager::NUMBER,
+                    'min'     => 1,
+                    'max'     => 4,
+                    'default' => 2,
+                )
+            );
+
+            $this->end_controls_section();
+
+            $this->start_controls_section(
+                'section_shortcuts',
+                array(
+                    'label' => __( 'Quick Links', 'elementor-admin-dashboard' ),
+                )
+            );
+
+            $repeater = new Repeater();
+
+            $repeater->add_control(
+                'shortcut_label',
+                array(
+                    'label'   => __( 'Label', 'elementor-admin-dashboard' ),
+                    'type'    => Controls_Manager::TEXT,
+                    'default' => __( 'Dashboard', 'elementor-admin-dashboard' ),
+                )
+            );
+
+            $repeater->add_control(
+                'shortcut_url',
+                array(
+                    'label'       => __( 'URL', 'elementor-admin-dashboard' ),
+                    'type'        => Controls_Manager::URL,
+                    'placeholder' => __( 'https://example.com', 'elementor-admin-dashboard' ),
+                )
+            );
+
+            $this->add_control(
+                'shortcuts',
+                array(
+                    'label'       => __( 'Shortcut Links', 'elementor-admin-dashboard' ),
+                    'type'        => Controls_Manager::REPEATER,
+                    'fields'      => $repeater->get_controls(),
+                    'title_field' => '{{{ shortcut_label }}}',
+                )
+            );
+
+            $this->end_controls_section();
+
+            $this->start_controls_section(
+                'section_content_style',
+                array(
+                    'label' => __( 'Cards', 'elementor-admin-dashboard' ),
+                    'tab'   => Controls_Manager::TAB_STYLE,
+                )
+            );
+
+            $this->add_group_control(
+                Group_Control_Typography::get_type(),
+                array(
+                    'name'     => 'card_typography',
+                    'selector' => '{{WRAPPER}} .ade-dashboard-card-title',
+                )
+            );
+
+            $this->add_control(
+                'card_background',
+                array(
+                    'label'     => __( 'Background Color', 'elementor-admin-dashboard' ),
+                    'type'      => Controls_Manager::COLOR,
+                    'selectors' => array(
+                        '{{WRAPPER}} .ade-dashboard-card' => 'background-color: {{VALUE}};',
+                    ),
+                )
+            );
+
+            $this->add_control(
+                'card_text_color',
+                array(
+                    'label'     => __( 'Text Color', 'elementor-admin-dashboard' ),
+                    'type'      => Controls_Manager::COLOR,
+                    'selectors' => array(
+                        '{{WRAPPER}} .ade-dashboard-card' => 'color: {{VALUE}};',
+                    ),
+                )
+            );
+
+            $this->add_group_control(
+                Group_Control_Border::get_type(),
+                array(
+                    'name'     => 'card_border',
+                    'selector' => '{{WRAPPER}} .ade-dashboard-card',
+                )
+            );
+
+            $this->add_group_control(
+                Group_Control_Box_Shadow::get_type(),
+                array(
+                    'name'     => 'card_shadow',
+                    'selector' => '{{WRAPPER}} .ade-dashboard-card',
+                )
+            );
+
+            $this->add_responsive_control(
+                'card_padding',
+                array(
+                    'label'      => __( 'Padding', 'elementor-admin-dashboard' ),
+                    'type'       => Controls_Manager::DIMENSIONS,
+                    'size_units' => array( 'px', 'em', '%' ),
+                    'selectors'  => array(
+                        '{{WRAPPER}} .ade-dashboard-card' => 'padding: {{TOP}}{{UNIT}} {{RIGHT}}{{UNIT}} {{BOTTOM}}{{UNIT}} {{LEFT}}{{UNIT}};',
+                    ),
+                )
+            );
+
+            $this->end_controls_section();
+
+            $this->start_controls_section(
+                'section_shortcut_style',
+                array(
+                    'label' => __( 'Quick Links', 'elementor-admin-dashboard' ),
+                    'tab'   => Controls_Manager::TAB_STYLE,
+                )
+            );
+
+            $this->add_control(
+                'shortcut_alignment',
+                array(
+                    'label'     => __( 'Alignment', 'elementor-admin-dashboard' ),
+                    'type'      => Controls_Manager::CHOOSE,
+                    'options'   => array(
+                        'flex-start' => array(
+                            'title' => __( 'Left', 'elementor-admin-dashboard' ),
+                            'icon'  => 'eicon-text-align-left',
+                        ),
+                        'center'     => array(
+                            'title' => __( 'Center', 'elementor-admin-dashboard' ),
+                            'icon'  => 'eicon-text-align-center',
+                        ),
+                        'flex-end'   => array(
+                            'title' => __( 'Right', 'elementor-admin-dashboard' ),
+                            'icon'  => 'eicon-text-align-right',
+                        ),
+                    ),
+                    'default'   => 'flex-start',
+                    'selectors' => array(
+                        '{{WRAPPER}} .ade-dashboard-shortcuts' => 'justify-content: {{VALUE}};',
+                    ),
+                )
+            );
+
+            $this->add_group_control(
+                Group_Control_Typography::get_type(),
+                array(
+                    'name'     => 'shortcut_typography',
+                    'selector' => '{{WRAPPER}} .ade-dashboard-shortcut a',
+                )
+            );
+
+            $this->add_control(
+                'shortcut_color',
+                array(
+                    'label'     => __( 'Link Color', 'elementor-admin-dashboard' ),
+                    'type'      => Controls_Manager::COLOR,
+                    'selectors' => array(
+                        '{{WRAPPER}} .ade-dashboard-shortcut a' => 'color: {{VALUE}};',
+                    ),
+                )
+            );
+
+            $this->add_control(
+                'shortcut_hover_color',
+                array(
+                    'label'     => __( 'Hover Color', 'elementor-admin-dashboard' ),
+                    'type'      => Controls_Manager::COLOR,
+                    'selectors' => array(
+                        '{{WRAPPER}} .ade-dashboard-shortcut a:hover' => 'color: {{VALUE}};',
+                    ),
+                )
+            );
+
+            $this->end_controls_section();
+        }
+
+        /**
+         * Render widget output on the frontend.
+         */
+        protected function render() {
+            $settings = $this->get_settings_for_display();
+            $metrics  = $this->get_metrics( $settings );
+
+            $layout  = ! empty( $settings['layout_style'] ) ? sanitize_html_class( $settings['layout_style'] ) : 'cards';
+            $columns = isset( $settings['columns'] ) ? absint( $settings['columns'] ) : 2;
+            $columns = max( 1, min( 4, $columns ) );
+
+            $this->add_render_attribute( 'wrapper', 'class', array( 'ade-dashboard-wrapper', 'ade-layout-' . $layout ) );
+            $this->add_render_attribute( 'wrapper', 'data-columns', $columns );
+
+            echo '<div ' . $this->get_render_attribute_string( 'wrapper' ) . '>';
+
+            if ( ! empty( $metrics ) ) {
+                echo '<div class="ade-dashboard-metrics">';
+                foreach ( $metrics as $metric ) {
+                    echo '<div class="ade-dashboard-card">';
+                    echo '<div class="ade-dashboard-card-title">' . esc_html( $metric['label'] ) . '</div>';
+                    echo '<div class="ade-dashboard-card-value">' . esc_html( $metric['value'] ) . '</div>';
+                    echo '</div>';
+                }
+                echo '</div>';
+            }
+
+            if ( ! empty( $settings['shortcuts'] ) ) {
+                echo '<div class="ade-dashboard-shortcuts">';
+                foreach ( $settings['shortcuts'] as $shortcut ) {
+                    if ( empty( $shortcut['shortcut_label'] ) || empty( $shortcut['shortcut_url']['url'] ) ) {
+                        continue;
+                    }
+
+                    $this->add_link_attributes( 'shortcut_' . $shortcut['_id'], $shortcut['shortcut_url'] );
+
+                    echo '<div class="ade-dashboard-shortcut">';
+                    echo '<a ' . $this->get_render_attribute_string( 'shortcut_' . $shortcut['_id'] ) . '>' . esc_html( $shortcut['shortcut_label'] ) . '</a>';
+                    echo '</div>';
+                }
+                echo '</div>';
+            }
+
+            echo '</div>';
+        }
+
+        /**
+         * Get metrics data.
+         *
+         * @param array $settings Widget settings.
+         *
+         * @return array
+         */
+        protected function get_metrics( $settings ) {
+            $metrics = array();
+
+            if ( 'yes' === $settings['show_posts'] ) {
+                $count_post = wp_count_posts( 'post' );
+                $metrics[]  = array(
+                    'label' => __( 'Posts', 'elementor-admin-dashboard' ),
+                    'value' => isset( $count_post->publish ) ? number_format_i18n( $count_post->publish ) : '0',
+                );
+            }
+
+            if ( 'yes' === $settings['show_pages'] ) {
+                $count_page = wp_count_posts( 'page' );
+                $metrics[]  = array(
+                    'label' => __( 'Pages', 'elementor-admin-dashboard' ),
+                    'value' => isset( $count_page->publish ) ? number_format_i18n( $count_page->publish ) : '0',
+                );
+            }
+
+            if ( 'yes' === $settings['show_comments'] ) {
+                $count_comments = wp_count_comments();
+                $metrics[]      = array(
+                    'label' => __( 'Comments', 'elementor-admin-dashboard' ),
+                    'value' => number_format_i18n( $count_comments->approved ),
+                );
+            }
+
+            if ( 'yes' === $settings['show_users'] ) {
+                $count_users = count_users();
+                $metrics[]   = array(
+                    'label' => __( 'Users', 'elementor-admin-dashboard' ),
+                    'value' => number_format_i18n( $count_users['total_users'] ),
+                );
+            }
+
+            /**
+             * Allow developers to filter the metrics displayed in the dashboard.
+             *
+             * @param array $metrics  Metrics array.
+             * @param array $settings Widget settings.
+             */
+            return apply_filters( 'elementor_admin_dashboard_metrics', $metrics, $settings );
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add an Elementor-ready admin dashboard plugin that surfaces WordPress metrics and shortcut links
- register assets, custom post type, and Elementor widget controls for layout and styling
- document installation and usage instructions for the new plugin

## Testing
- php -l elementor-admin-dashboard/admin-dashboard-elementor.php
- php -l elementor-admin-dashboard/includes/class-admin-dashboard-plugin.php
- php -l elementor-admin-dashboard/includes/class-elementor-admin-dashboard-widget.php

------
https://chatgpt.com/codex/tasks/task_e_68cb107be614832c81ccbbf2fb278214